### PR TITLE
数種のGT蜂が交配できない問題を修正

### DIFF
--- a/src/main/java/com/github/gtexpert/gtbm/core/CoreModule.java
+++ b/src/main/java/com/github/gtexpert/gtbm/core/CoreModule.java
@@ -1,6 +1,16 @@
 package com.github.gtexpert.gtbm.core;
 
+import com.github.gtexpert.gtbm.loaders.recipe.CEuOverrideRecipe;
+
+import gregtech.api.unification.OreDictUnifier;
+
+import gregtech.common.blocks.MetaBlocks;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 import org.apache.logging.log4j.LogManager;
@@ -38,5 +48,10 @@ public class CoreModule implements IModule {
         proxy.preInit(event);
 
         logger.info("Hello World!");
+    }
+
+    @Override
+    public void registerRecipesLowest(RegistryEvent.Register<IRecipe> event) {
+        CEuOverrideRecipe.init();
     }
 }

--- a/src/main/java/com/github/gtexpert/gtbm/core/CoreModule.java
+++ b/src/main/java/com/github/gtexpert/gtbm/core/CoreModule.java
@@ -1,27 +1,25 @@
 package com.github.gtexpert.gtbm.core;
 
-import com.github.gtexpert.gtbm.loaders.recipe.CEuOverrideRecipe;
-
-import gregtech.api.unification.OreDictUnifier;
-
-import gregtech.common.blocks.MetaBlocks;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
+import gregtech.api.GTValues;
+import gregtech.api.unification.OreDictUnifier;
+import gregtech.common.blocks.MetaBlocks;
+
 import com.github.gtexpert.gtbm.Tags;
 import com.github.gtexpert.gtbm.api.ModValues;
 import com.github.gtexpert.gtbm.api.modules.IModule;
 import com.github.gtexpert.gtbm.api.modules.TModule;
 import com.github.gtexpert.gtbm.common.CommonProxy;
+import com.github.gtexpert.gtbm.loaders.recipe.CEuOverrideRecipe;
 import com.github.gtexpert.gtbm.module.Modules;
 
 @TModule(
@@ -48,6 +46,11 @@ public class CoreModule implements IModule {
         proxy.preInit(event);
 
         logger.info("Hello World!");
+    }
+
+    @Override
+    public void registerRecipesLow(RegistryEvent.Register<IRecipe> event) {
+        OreDictUnifier.registerOre(new ItemStack(MetaBlocks.RUBBER_LOG, 1, GTValues.W), "logRubber");
     }
 
     @Override

--- a/src/main/java/com/github/gtexpert/gtbm/loaders/recipe/CEuOverrideRecipe.java
+++ b/src/main/java/com/github/gtexpert/gtbm/loaders/recipe/CEuOverrideRecipe.java
@@ -1,0 +1,27 @@
+package com.github.gtexpert.gtbm.loaders.recipe;
+
+import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.unification.material.Materials;
+
+import static gregtech.api.unification.ore.OrePrefix.*;
+
+public class CEuOverrideRecipe {
+
+    public static void init() {
+        material();
+    }
+
+    public static void material() {
+        // Arsenic Block
+        RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder()
+                .input(dust, Materials.Arsenic, 9)
+                .output(block, Materials.Arsenic)
+                .duration(300).EUt(2).buildAndRegister();
+
+        // TricalciumPhosphate Block
+        RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder()
+                .input(dust, Materials.TricalciumPhosphate, 9)
+                .output(block, Materials.TricalciumPhosphate)
+                .duration(300).EUt(2).buildAndRegister();
+    }
+}


### PR DESCRIPTION
- Rubber Logに`logRubber`を追加
- ブロックレシピが生成されてなかったものにレシピを追加 (2.9対応で要削除)

※[こちら](https://github.com/GTModpackTeam/GregTech-Expert-2/issues/402)の下２つの修正です。