### PR TITLE
chore: add CodeRabbit config and make AGENTS.md canonical

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,49 @@
+knowledge_base:
+  mcp:
+    # "auto" disables MCP for public repositories, so set it explicitly.
+    # This is what allows the DeepWiki MCP server to be used as review context.
+    usage: enabled
+
+reviews:
+  path_instructions:
+    - path: "src/main/java/**/*.java"
+      instructions: |
+        Minecraft 1.12.2 Forge mod (GTBeesMatrix / GTBM), an add-on for
+        GregTech CE: Unofficial (GTCEu, https://github.com/GregTechCEu/GregTech).
+        Also integrates with Forestry, Binnie's Mods (Extra Bees, Extra Trees),
+        Gendustry, GregTech Food Option (GTFO) and The One Probe.
+
+        GTCEu context — use DeepWiki (GregTechCEu/GregTech) to verify:
+        - Confirm GTCEu APIs, registries, recipe builders and multiblock/apiary
+          related classes are used correctly, and that referenced methods/fields
+          actually exist in the pinned GTCEu version.
+        - Flag use of GTCEu internals that are not part of its public API when a
+          public equivalent exists.
+
+        Platform constraints (1.12.2 / Java 8 bytecode):
+        - Do NOT suggest Java APIs or language features unavailable on this platform
+          (e.g. `List.of`, records, switch expressions, text blocks).
+        - Do NOT suggest modern Minecraft/Forge APIs; this is the 1.12.2 Forge line.
+
+        Side boundary:
+        - Flag client-only types or `@SideOnly(Side.CLIENT)` members referenced from
+          common/server code paths — this crashes a dedicated server.
+
+        Module system:
+        - Modules are annotated `@GTEModule` and discovered via ASM. Check that new
+          modules extend the correct base class and declare `modDependencies`
+          correctly for optional integrations.
+        - Integration modules under `integration/<mod>/` extend `GTBMIntegrationSubmodule`.
+
+        Mixins (`mixins/`, targets: chisel, draconicevolution, gcym, gregtech):
+        - Verify the target class, method signature and descriptor plausibly exist in
+          the targeted mod.
+        - Any new mixin must be registered in the matching mixin config.
+
+        Optional integrations:
+        - Optional mod integrations must be gated so a missing optional mod
+          (Gendustry, Binnie's Mods, GTFO, TOP) cannot crash the game.
+
+        Build:
+        - `build.gradle` is auto-generated. Never edit it
+          (configure via `buildscript.properties` / `dependencies.gradle`).

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,9 +30,10 @@ reviews:
           common/server code paths — this crashes a dedicated server.
 
         Module system:
-        - Modules are annotated `@GTEModule` and discovered via ASM. Check that new
-          modules extend the correct base class and declare `modDependencies`
-          correctly for optional integrations.
+        - Modules are annotated `@GTEModule` and discovered via Forge's `ASMDataTable`
+          annotation scanning (`modules/ModuleManager.java`), not bytecode rewriting.
+          Check that new modules extend the correct base class and declare
+          `modDependencies` correctly for optional integrations.
         - Integration modules under `integration/<mod>/` extend `GTBMIntegrationSubmodule`.
 
         Mixins (`mixins/`, targets: chisel, draconicevolution, gcym, gregtech):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## Project Overview
+
+GTBeesMatrix (GTBM) is a Minecraft 1.12.2 Forge mod that adds tweaks, fixes, and integrations for Forestry bees in GregTech-based modpacks. It extends GregTech CE Unofficial (CEu) with bee breeding fixes, GT machine recipes for bee products, and multiblock apiaries.
+
+Note: This project was renamed from GTExpert (GTE). Many internal class names still use the GTE prefix (e.g., `GTEModule`, `GTEModuleManager`, `BaseGTEModule`), but the mod ID and package path use `gtbm`.
+
+## Build Commands
+
+```bash
+# Setup development workspace (required first time)
+./gradlew setupDecompWorkspace
+
+# Build the mod
+./gradlew build
+
+# Run Minecraft client
+./gradlew runClient
+
+# Run Minecraft server
+./gradlew runServer
+
+# Apply code formatting (Spotless)
+./gradlew spotlessApply
+
+# Check code formatting
+./gradlew spotlessCheck
+
+# Run tests
+./gradlew test
+
+# Run a single test class
+./gradlew test --tests "com.github.gtexpert.core.GTETest"
+
+# Update buildscript to latest version
+./gradlew updateBuildScript
+```
+
+## Architecture
+
+### Module System
+
+The mod uses a custom module system for organizing features and integrations:
+
+- **Module Manager** (`modules/GTEModuleManager.java`): Discovers and loads modules via ASM, manages lifecycle events, and handles module dependencies
+- **Base Module** (`modules/BaseGTEModule.java`): Abstract base class all modules extend
+- **Module Container** (`modules/GTEModules.java`): Registers the main module container
+
+Modules are annotated with `@GTEModule` and automatically discovered at runtime. Module configuration is in `config/gtexpert/modules.cfg`.
+
+### Integration Modules
+
+Located in `integration/`, each subdirectory contains integration code for a specific mod:
+- `forestry` - Forestry (farms, bees, recipes)
+- `gendustry` - Gendustry (industrial apiary, bee status widget)
+- `binnies` - Binnie's Mods (Extra Bees, Extra Trees)
+- `gtfo` - GregTech Food Option
+- `top` - The One Probe (tooltip providers for apiaries)
+
+Integration modules extend `GTBMIntegrationSubmodule` and declare mod dependencies via the `@GTEModule(modDependencies = {...})` annotation.
+
+### Core Components
+
+- **CoreMod** (`core/GTECoreMod.java`): FML loading plugin that performs ASM transformations and handles dependency loading
+- **Mixins** (`mixins/`): Mixin classes organized by target mod (chisel, draconicevolution, gcym, gregtech)
+- **Common** (`common/`): Blocks, items, metatileentities, config, and event handlers
+- **API** (`api/`): Public API including recipes, materials, capabilities, and utilities
+- **Loaders** (`loaders/`): Recipe and material loaders
+
+### Key Dependencies
+
+- GregTech CE Unofficial (CEu) - Required
+- Forestry - Required
+- MixinBooter - Required for mixin support
+- GroovyScript - Required for scripting support
+
+## Code Style
+
+- **Formatting**: Enforced via Spotless using Eclipse formatter (run `./gradlew spotlessApply`)
+- **Import order**: Defined in `spotless.importorder` (gregtech, net, codechickenlib, other, javax/java, static)
+- **Line length**: 120 characters max
+- **Indentation**: 4 spaces
+
+## Configuration
+
+- `buildscript.properties`: Main build configuration (mod version, features, dependencies)
+- `dependencies.gradle`: Add new mod dependencies here
+- `repositories.gradle`: Add new maven repositories here
+- Debug flags in `buildscript.properties` enable runtime dependencies for specific mod integrations during development
+
+## Testing Integration Mods
+
+Enable debug flags in `buildscript.properties` to load specific mods at runtime:
+```properties
+debug_all = false       # Enable all optional mods
+debug_gendustry = true  # Enable just Gendustry
+debug_binnies = true    # Enable just Binnie's Mods
+debug_gtfo = true       # Enable just GregTech Food Option
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Successor to the removed Gemini Code Assist / Claude PR review setups.

## `.coderabbit.yaml`

- **`knowledge_base.mcp.usage: enabled`** — the default `auto` disables MCP for **public** repositories, which would stop the DeepWiki MCP server from being used as review context.
- **`reviews.path_instructions`** — this repo is a **GregTech CE: Unofficial** add-on, so the reviewer is told to verify GTCEu API/registry usage against DeepWiki (`GregTechCEu/GregTech`), respect the 1.12.2/Java 8 platform, check the module-system (`@GTEModule`) and mixin conventions, and confirm optional integrations (Gendustry, Binnie's Mods, GTFO, TOP) are gated.

## AGENTS.md / CLAUDE.md

`CLAUDE.md` (previously untracked/staged content) is renamed to `AGENTS.md` and `CLAUDE.md` becomes a symlink to it — matching Claude Code's own documented pattern (`ln -s AGENTS.md CLAUDE.md`) and letting CodeRabbit read the real content regardless of whether it follows the symlink or reads the git blob directly (confirmed via testing on `BetterLinkPartyClaim#8` that CodeRabbit does follow it, but this makes the setup robust either way).

The opening line was changed from "This file provides guidance to Claude Code (claude.ai/code)..." to a tool-neutral phrasing, since AGENTS.md is read by multiple tools (Claude Code, Codex, CodeRabbit), not just Claude Code.

Only these 3 files are included in this PR — the branch also carries unrelated in-progress work (module system refactor, `.serena/` memory files, `.mcp.json`) that is intentionally left untouched/uncommitted.

Note: origin was temporarily switched from HTTPS to SSH to push this branch, matching the other repos in the org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance covering project structure, build and test workflows, coding conventions, integrations, and debugging.
  * Added compatibility and integration guidance for Java and Minecraft development.
  * Added a linked reference so the same guidance is available through multiple assistant instruction files.

* **Chores**
  * Added automated review configuration with project-specific context and validation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->